### PR TITLE
Fix browser detection for AudioContext

### DIFF
--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -125,7 +125,7 @@ export const logError = (errorType, error, context = {}) => {
 export const checkBrowserSupport = () => {
   const features = {
     webGPU: !!navigator.gpu,
-    audioContext: !!window.AudioContext,
+    audioContext: !!(window.AudioContext || window.webkitAudioContext),
     mediaDevices: !!navigator.mediaDevices,
     getUserMedia: !!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia),
     webWorkers: !!window.Worker,


### PR DESCRIPTION
## Summary
- improve browser capability detection

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*