### PR TITLE
Clean up gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,32 +7,25 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
-node_modules
-dist
-dist-ssr
+# Build output
+dist/
+dist-ssr/
+
+# Local environment files
 *.local
 
-# Editor directories and files
+# Dependencies
+node_modules/
+venv/
+.venv/
+
+# IDE directories and files
 .vscode/*
 !.vscode/extensions.json
-.idea
+.idea/
 .DS_Store
 *.suo
 *.ntvs*
 *.njsproj
 *.sln
 *.sw?
-
-node_modules/*
-venv/*
-.venv/*
-
-node_modules/*
-venv/*
-.venv/*
-
-
-venv
-venv/
-node_modules/
-node_modules


### PR DESCRIPTION
## Summary
- remove duplicate patterns
- organize `.gitignore` into sections for logs, build output, IDE files, and dependencies

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*
- `npm test` *(fails: vitest not found)*